### PR TITLE
v0.7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 #  any later version.  See COPYING for more details.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.16)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 

--- a/src/vhCore/Miner.h
+++ b/src/vhCore/Miner.h
@@ -22,7 +22,7 @@
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "VerthashMiner"
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.7.0"
+#define PACKAGE_VERSION "0.7.1"
 
 // alloca detection
 #if !defined(alloca)
@@ -164,7 +164,7 @@ extern bool hex2bin(unsigned char *p, const char *hexstr, size_t len);
 extern int varint_encode(unsigned char *p, uint64_t n);
 extern size_t address_to_script(unsigned char *out, size_t outsz, const char *addr);
 extern bool fulltest(const uint32_t *hash, const uint32_t *target);
-extern void diff_to_target(uint32_t *target, double diff);
+extern void diff_to_target(unsigned char *dest_target, double diff, double diff_multiplier);
 
 //-----------------------------------------------------------------------------
 // Stratum API

--- a/src/vhCore/Verthash.h
+++ b/src/vhCore/Verthash.h
@@ -18,6 +18,7 @@
 // Verthash constants used to compute bitmask, used inside kernel during IO pass
 #define VH_HASH_OUT_SIZE 32
 #define VH_BYTE_ALIGNMENT 16
+#define VH_HEADER_SIZE 80
 
 //-----------------------------------------------------------------------------
 // Verthash data
@@ -40,9 +41,13 @@ int verthash_info_init(verthash_info_t* info, const char* file_name);
 //! Reset all fields and free allocated data.
 void verthash_info_free(verthash_info_t* info);
 
-
 //! Generate verthash data file and save it to specified location.
 int verthash_generate_data_file(const char* output_file_name);
+
+void verthash_hash(const unsigned char* blob_bytes,
+                   const size_t blob_size,
+                   const unsigned char(*input)[VH_HEADER_SIZE],
+                   unsigned char(*output)[VH_HASH_OUT_SIZE]);
 
 #endif // !Verthash_INCLUDE_ONCE
 

--- a/src/vhDevice/ADLUtils.cpp
+++ b/src/vhDevice/ADLUtils.cpp
@@ -124,11 +124,7 @@ int adlInitApi(void)
         NULL == pADL2_Adapter_NumberOfAdapters_Get ||
         NULL == pADL2_Adapter_AdapterInfo_Get ||
         NULL == pADL2_Adapter_ID_Get ||
-        NULL == pADL2_Overdrive_Caps ||
-        NULL == pADL2_Overdrive5_Temperature_Get ||
-        NULL == pADL2_Overdrive6_Temperature_Get ||
-        NULL == pADL2_OverdriveN_Temperature_Get ||
-        NULL == pADL2_New_QueryPMLogData_Get)
+        NULL == pADL2_Overdrive_Caps)
     {
         return -3; // ERROR_FAILED_TO_RETRIEVE_FUNCTIONS;
     }

--- a/src/vhDevice/ConfigGenerator.h
+++ b/src/vhDevice/ConfigGenerator.h
@@ -233,8 +233,8 @@ static void generateCUDADeviceConfig(const std::vector<cudevice_t>& cudevices,
         else
         {
             char pcieStr[9] = { };
-            snprintf (pcieStr, 8, "%02x:%02x:%01x",
-                      cudevice.pcieBusId, cudevice.pcieDeviceId, cudevice.pcieFunctionId);
+            snprintf (pcieStr, 8, "%02x:%02x:0",
+                      cudevice.pcieBusId, cudevice.pcieDeviceId);
             deviceListText += std::string(pcieStr);
         }
 

--- a/src/vhDevice/DeviceUtils.h
+++ b/src/vhDevice/DeviceUtils.h
@@ -90,7 +90,7 @@ namespace vh
         // PCIe stuff
         int32_t pcieBusId;
         int32_t pcieDeviceId;
-        int32_t pcieFunctionId;
+        int32_t pcieFunctionId; // 0 for NVIDIA devices
 
         // ASM program handling
         EAsmProgram asmProgram;
@@ -108,7 +108,6 @@ namespace vh
         // PCIe stuff
         int32_t pcieBusId;
         int32_t pcieDeviceId;
-        int32_t pcieFunctionId;
     };
 #endif
     //-----------------------------------------------------------------------------


### PR DESCRIPTION
- Changed "difficulty to target" formula to a more reliable one.
- Miner will no longer load NVML and ADL libraries when they are not needed.
- OpenCL back-end will now report error codes along with messages.
- Fixed NVIDIA OpenCL devices restrictions when compiled with CUDA 10 or lower.
- Added GPU memory errors tracker. Invalid shares will be discarded.
- Lowered ADL library version requirements.
- Lowered CMake version requirements.